### PR TITLE
Rca log rate limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 requests = "^2.25.1"
 singer-python = "^5.9.1"
 python-dotenv = "^0.15.0"
+ratelimit = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"


### PR DESCRIPTION
# Description :: User Story

Add log lines to more clearly show the status of the tap as it is working.

Add Ratelimit package to control the calls per second that Treez (5 calls per 1 second)

## Type of Change

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [x] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes

Details:
