### PR TITLE
Rca missing tickets bug

### DIFF
--- a/tap_treez/streams.py
+++ b/tap_treez/streams.py
@@ -8,9 +8,7 @@ from ratelimit import limits, sleep_and_retry
 
 LOGGER = singer.get_logger()
 
-def bookmark_time():
-    return datetime.strftime((datetime.now() + timedelta(seconds=1)),
-                             "%Y-%m-%dT%H:%M:%S.000Z")
+
 
 
 
@@ -54,11 +52,6 @@ class ProductInfo(CatalogStream):
             last_updated_at = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
 
-        singer.write_bookmark(self.state,
-                              self.tap_stream_id,
-                              self.replication_key,
-                              bookmark_time())
-
         while response_length >= 50:
             response = self.client.fetch_products(
                 page=current_page, last_updated_date=last_updated_at)
@@ -97,11 +90,6 @@ class CustomerInfo(CatalogStream):
         if last_updated == None:
             last_updated = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
-
-        singer.write_bookmark(self.state,
-                              self.tap_stream_id,
-                              self.replication_key,
-                              bookmark_time())
 
         while response_length >= 50:
             response = self.client.fetch_customers(
@@ -142,11 +130,6 @@ class TicketInfo(CatalogStream):
         if last_updated_at == None:
             last_updated_at = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
-
-        singer.write_bookmark(self.state,
-                              self.tap_stream_id,
-                              self.replication_key,
-                              bookmark_time())
 
         while response_length >= 25:
             response = self.client.fetch_tickets(

--- a/tap_treez/streams.py
+++ b/tap_treez/streams.py
@@ -8,6 +8,11 @@ from ratelimit import limits, sleep_and_retry
 
 LOGGER = singer.get_logger()
 
+def bookmark_time():
+    return datetime.strftime((datetime.now() + timedelta(seconds=1)),
+                             "%Y-%m-%dT%H:%M:%S.000Z")
+
+
 
 class Stream:
     tap_stream_id           = None
@@ -49,6 +54,11 @@ class ProductInfo(CatalogStream):
             last_updated_at = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
 
+        singer.write_bookmark(self.state,
+                              self.tap_stream_id,
+                              self.replication_key,
+                              bookmark_time())
+
         while response_length >= 50:
             response = self.client.fetch_products(
                 page=current_page, last_updated_date=last_updated_at)
@@ -87,6 +97,11 @@ class CustomerInfo(CatalogStream):
         if last_updated == None:
             last_updated = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
+
+        singer.write_bookmark(self.state,
+                              self.tap_stream_id,
+                              self.replication_key,
+                              bookmark_time())
 
         while response_length >= 50:
             response = self.client.fetch_customers(
@@ -127,6 +142,11 @@ class TicketInfo(CatalogStream):
         if last_updated_at == None:
             last_updated_at = datetime.strftime(
                 datetime.now(), "%Y-%m-%dT00:00:00.000Z")
+
+        singer.write_bookmark(self.state,
+                              self.tap_stream_id,
+                              self.replication_key,
+                              bookmark_time())
 
         while response_length >= 25:
             response = self.client.fetch_tickets(

--- a/tap_treez/sync.py
+++ b/tap_treez/sync.py
@@ -46,11 +46,6 @@ def sync(config, state, catalog):
                 )
                 records += 1
             
-            if replication_key != 'date_closed':
-                singer.write_bookmark(state, 
-                    tap_stream_id, 
-                    replication_key, 
-                    datetime.now().strftime("%Y-%m-%dT%H:%M:%S.000Z"))
             LOGGER.info(f"Total Records written: {records}")
             singer.write_state(state)
 

--- a/tap_treez/sync.py
+++ b/tap_treez/sync.py
@@ -21,7 +21,6 @@ def sync(config, state, catalog):
         for stream in catalog.get_selected_streams(state):
             tap_stream_id = stream.tap_stream_id
             stream_obj = STREAMS[tap_stream_id](client, state)
-            replication_key = stream_obj.replication_key
             stream_schema = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)
 


### PR DESCRIPTION
# Description :: User Story

Purple Lotus was finding there were missing a small number of tickets each day.  This was due to the stream not bookmarking a time until it was done and any tickets that entered the system between start and end would be missed since the api loads them as a stack.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes

Details:

The start time of a stream is set in the beginning and them after the stream is successful it is put in the bookmark for the target to handle